### PR TITLE
Fix closure problem in guzzle bundle provider

### DIFF
--- a/src/Provider/GuzzleProfilerServiceProvider.php
+++ b/src/Provider/GuzzleProfilerServiceProvider.php
@@ -25,9 +25,11 @@ class GuzzleProfilerServiceProvider implements ServiceProviderInterface
             );
         }
 
-        $dataCollectorTpls   = $app->raw('data_collector.templates');
-        $dataCollectorTpls[] = ['guzzle', '@CampruGuzzle/views/Collector/guzzle.html.twig'];
-        $app['data_collector.templates'] = $dataCollectorTpls;
+        $app['data_collector.templates'] = $app->extend('data_collector.templates', function ($tpls) {
+            $tpls[] = ['guzzle', '@CampruGuzzle/views/Collector/guzzle.html.twig'];
+
+            return $tpls;
+        });
 
         $app['guzzle_bundle.subscriber.profiler'] = $app->share(function () {
             return new \GuzzleHttp\Subscriber\History;


### PR DESCRIPTION
- In Silex web-profiler 1.0.7, data_collector.templates is a closure and
  it's needed to extend to add guzzle bundle tpls
